### PR TITLE
issue #15: changed references to scope to router

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -94,7 +94,7 @@ Loads model populated by `fetchModel` pipeline
 
 ### getPath
 
-Gets path of the request - it's relative to current `scope`
+Gets path of the request - it's relative to current `router`
 
 **Type:** `HttpContext -> string`
 

--- a/docs/api/router.md
+++ b/docs/api/router.md
@@ -1,15 +1,15 @@
-# Scope
+# Router
 
-## Scope builder
+## Router builder
 
-Computation expression used to creating routing and combining `HttpHandlers`, `pipelines` and `controllers` together.
+Computation expression used to create routing, combining `HttpHandlers`, `pipelines` and `controllers` together.
 
 Result of the computation expression is standard Giraffe's `HttpHandler`which means that it's easily composable with other parts of the ecosytem.
 
 **Example:**
 
 ```fsharp
-let topRouter = scope {
+let topRouter = router {
     pipe_through headerPipe
     not_found_handler (text "404")
 
@@ -18,8 +18,8 @@ let topRouter = scope {
     getf "/name/%s" helloWorldName
     getf "/name/%s/%i" helloWorldNameAge
 
-    //scopes can be defined inline to simulate `subRoute` combinator
-    forward "/other" (scope {
+    //routers can be defined inline to simulate `subRoute` combinator
+    forward "/other" (router {
         pipe_through otherHeaderPipe
         not_found_handler (text "Other 404")
 
@@ -45,7 +45,7 @@ Adds handler for `GET` request.
 
 ### getf
 
-Adds handler for `GET` request using formater.
+Adds handler for `GET` request using formatter.
 
 **Input:**: `PrintfFormat<_,_,_,_'f> * ('f -> HttpHandler)`
 
@@ -57,7 +57,7 @@ Adds handler for `POST` request.
 
 ### postf
 
-Adds handler for `POST` request using formater.
+Adds handler for `POST` request using formatter.
 
 **Input:**: `PrintfFormat<_,_,_,_'f> * ('f -> HttpHandler)`
 
@@ -69,7 +69,7 @@ Adds handler for `PUT` request.
 
 ### putf
 
-Adds handler for `PUT` request using formater.
+Adds handler for `PUT` request using formatter.
 
 **Input:**: `PrintfFormat<_,_,_,_'f> * ('f -> HttpHandler)`
 
@@ -81,7 +81,7 @@ Adds handler for `DELETE` request.
 
 ### deletef
 
-Adds handler for `DELETE` request using formater.
+Adds handler for `DELETE` request using formatter.
 
 **Input:**: `PrintfFormat<_,_,_,_'f> * ('f -> HttpHandler)`
 
@@ -93,13 +93,13 @@ Adds handler for `PATCH` request.
 
 ### patchf
 
-Adds handler for `PATCH` request using formater.
+Adds handler for `PATCH` request using formatter.
 
 **Input:**: `PrintfFormat<_,_,_,_'f> * ('f -> HttpHandler)`
 
 ### forward
 
-Forwards calls to different `scope`. Modifies the `HttpRequest.Path` to allow subrouting.
+Forwards calls to different `router`. Modifies the `HttpRequest.Path` to allow subrouting.
 
 **Input:**: `string * HttpHandler`
 
@@ -111,6 +111,6 @@ Adds pipeline to the list of pipelines that will be used for every request
 
 ### not_found_handler
 
-Adds not-found handler for current scope
+Adds not-found handler for current router
 
 **Input:**: `HttpHandler`

--- a/docs/guides/adding-pages.md
+++ b/docs/guides/adding-pages.md
@@ -49,7 +49,7 @@ module Controller =
     let indexAction =
         htmlView (Views.index)
 
-    let helloView = scope {
+    let helloView = router {
         get "/" indexAction
     }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Built on top of the battle-tested ASP.NET Core foundation and the highly flexibl
 Saturn is made up of a number of distinct parts, each with its own purpose and role to play in building a web application.
 
  - Application
-    - the start and end of the request lifecycle
+    - the start and end of the request life cycle
     - handles all aspects of requests up until the point where the router takes over
     - provides a core set of plugs to apply to all requests
     - dispatches requests into a router

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ pages:
     - Adding Pages: 'guides/adding-pages.md'
   - Api Reference:
     - Pipeline: 'api/pipeline.md'
-    - Scope: 'api/scope.md'
+    - Router: 'api/router.md'
     - Controller: 'api/controller.md'
     - Application: 'api/application.md'
 


### PR DESCRIPTION
Issue #15 

Changed references to `scope` to `router`. Fixed a few misspellings and a bit of sentence structure to read better.

Scope was changed to router in release 0.70
Here are the release notes
https://github.com/SaturnFramework/Saturn/blob/8eaf13ef4ae42875618410e867db9b7681458c31/RELEASE_NOTES.md#070---13072018